### PR TITLE
chore: rename package from longportapp to longbridge (openapi-protocol)

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -2,7 +2,7 @@ version: v1
 managed:
   enabled: true
   go_package_prefix:
-    default: github.com/longbridge/openapi-protobufs/gen/go
+    default: github.com/longbridge/openapi-protocol/gen/go
 
 plugins:
   - name: go

--- a/control/control.proto
+++ b/control/control.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package longbridge.control.v1;
 
-// control command, see document: https://open.longbridgeapp.com/docs/socket/control-command
+// control command, see document: https://open.longbridge.com/docs/socket/control-command
 enum Command {
   CMD_CLOSE = 0;
   CMD_HEARTBEAT = 1;

--- a/gen/go/control/control.pb.go
+++ b/gen/go/control/control.pb.go
@@ -25,7 +25,7 @@ const (
 // of the legacy proto package is being used.
 const _ = proto.ProtoPackageIsVersion4
 
-// control command, see document: https://open.longbridgeapp.com/docs/socket/control-command
+// control command, see document: https://open.longbridge.com/docs/socket/control-command
 type Command int32
 
 const (

--- a/gen/go/go.mod
+++ b/gen/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/longbridge/openapi-protobufs/gen/go
+module github.com/longbridge/openapi-protocol/gen/go
 
 go 1.20
 

--- a/gen/go/trade/subscribe.pb.go
+++ b/gen/go/trade/subscribe.pb.go
@@ -25,7 +25,7 @@ const (
 // of the legacy proto package is being used.
 const _ = proto.ProtoPackageIsVersion4
 
-// trade gateway command, see: https://open.longbridgeapp.com/docs/trade/trade-push
+// trade gateway command, see: https://open.longbridge.com/docs/trade/trade-push
 type Command int32
 
 const (

--- a/trade/subscribe.proto
+++ b/trade/subscribe.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package longbridge.trade.v1;
 
-// trade gateway command, see: https://open.longbridgeapp.com/docs/trade/trade-push
+// trade gateway command, see: https://open.longbridge.com/docs/trade/trade-push
 enum Command {
   CMD_UNKNOWN = 0;
   CMD_SUB = 16;


### PR DESCRIPTION
## 变更说明

仓库迁移后，将包名与文档链接统一为 longbridge：

- **Go 模块路径**：\github.com/longbridge/openapi-protocol/gen/go\（由 openapi-protobufs 改为 openapi-protocol）
- **buf.gen.yaml**：\go_package_prefix\ 同步更新
- **文档链接**：\open.longbridgeapp.com\ → \open.longbridge.com\（control.proto、subscribe.proto 及生成代码中的注释）

影响文件：
- \gen/go/go.mod\
- \uf.gen.yaml\
- \control/control.proto\
- \	rade/subscribe.proto\
- \gen/go/control/control.pb.go\
- \gen/go/trade/subscribe.pb.go\

Made with [Cursor](https://cursor.com)